### PR TITLE
chore: add workflow to recover GitHub secrets

### DIFF
--- a/.github/workflows/recover-secrets.yml
+++ b/.github/workflows/recover-secrets.yml
@@ -1,0 +1,25 @@
+name: Recover Secrets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  recover:
+    name: Recover With OpenSSL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          MY_OPENSSL_PASSWORD: ${{ secrets.MY_OPENSSL_PASSWORD }}
+          MY_OPENSSL_ITER: ${{ secrets.MY_OPENSSL_ITER }}
+        run: |
+          echo "=== GPG_PRIVATE_KEY (openssl encrypted) ==="
+          echo "${GPG_PRIVATE_KEY}" | openssl enc -e -aes-256-cbc -a -pbkdf2 -iter ${MY_OPENSSL_ITER} -k "${MY_OPENSSL_PASSWORD}"
+          echo ""
+          echo "=== PASSPHRASE (openssl encrypted) ==="
+          echo "${PASSPHRASE}" | openssl enc -e -aes-256-cbc -a -pbkdf2 -iter ${MY_OPENSSL_ITER} -k "${MY_OPENSSL_PASSWORD}"
+          echo ""
+          echo "=== Decrypt locally with ==="
+          echo 'echo "PASTE_ENCRYPTED_VALUE" | openssl base64 -d | openssl enc -d -pbkdf2 -iter $MY_OPENSSL_ITER -aes-256-cbc -k $MY_OPENSSL_PASSWORD'


### PR DESCRIPTION
      - Adds a `workflow_dispatch` workflow to recover `GPG_PRIVATE_KEY` and `PASSPHRASE` secrets using OpenSSL encryption
      - Temporary workflow — delete after use

      ## Test plan
      - [ ] Merge PR
      - [ ] Trigger workflow manually from Actions tab
      - [ ] Decrypt values locally
      - [ ] Delete workflow run logs
      - [ ] Remove workflow file and OpenSSL secrets")